### PR TITLE
Adding JMS Consumer/Publisher Client

### DIFF
--- a/JMS-Publisher-Consumer-Client/README.md
+++ b/JMS-Publisher-Consumer-Client/README.md
@@ -1,0 +1,95 @@
+# JMS Consumer/Publisher Client
+
+This JMS client is useful in a situation where JMS events haven't been consumed correctly by the gateway, as indicated by the gateway listener debug logs. Even though the event publisher log adaptor is configured for the relevant stream, shows that the message was received in the event stream. It doesn’t imply that the event was properly published to the broker through the JMSeventPublisher. So that the source of the issue between the JMS publisher flow and the consumption flow remains unidentified. To address this, the tool allows manual listening to the broker to verify if an event was published. Also, this tool enables the manual publishing of an event to the broker. This process helps ascertain whether the gateway server appropriately consumed the event, as observed through the gateway listener debug logs.
+
+## Building the Tool
+
+Follow these steps to build the tool:
+
+1. Clone the repository and navigate to the project's root folder (JMS-Publisher-Consumer-Client).
+2. Build the project using Maven:
+
+   ```sh
+   mvn clean install
+   ```
+
+3. Once the build is successful, find the `JMS-Publisher-Consumer-Client-1.0.0.zip` in the `target` directory.
+
+## Usage
+
+1. Copy the `JMSPublisherConsumerClient-1.0.0.zip` to your preferred location and extract it:
+
+   ```sh
+   unzip ./JMS-Publisher-Consumer-Client-1.0.0.zip -d .
+   ```
+
+2. Configure the `config.properties` file with your broker settings.
+
+3. To consume events from the broker, run:
+
+   ```sh
+   java -jar JMS-Publisher-Consumer-Client-1.0.0.jar
+   ```
+
+4. To manually publish an event to the broker, execute:
+
+   ```sh
+   java -cp JMS-Publisher-Consumer-Client-1.0.0.jar org.wso2.test.jmsPublisherConsumerClient.EventPublisher
+   ```
+
+## Sample Output
+
+Successful event consumption:
+
+```
+-------- EVENT RECEIVED -------------
+EVENT RECEIVED :{"eventType":"DEPLOY_API_IN_GATEWAY","timestamp":1693323252994,"event":...}
+DECRYPTED PAYLOAD :{"apiId":0,"uuid":"732e4a17-5767-443d-bf24-319c52948877","name":"asa",...}
+----------------------------
+```
+
+Successful event publication:
+
+```
+! Event was successfully published to the broker !
+```
+
+Absolutely, here's a template for describing the configuration parameters in your README:
+
+## Configuration
+
+Before you start using the JMS Consumer/Publisher Client, you'll need to configure the `config.properties` file with the necessary settings. Here's what each parameter in the configuration file means:
+
+### Broker Configuration
+
+- **`brokerUrl`**: The URL of the JMS broker where events are published and consumed. Replace `localhost` and `5672` with the actual hostname and port of your broker.
+
+- **`username`**: Your username for authenticating with the JMS broker.
+
+- **`password`**: The password associated with the provided username (please add a url encoded value for the password if there is any special characters in your broker password ).
+
+- **`topicName`**: The name of the topic to which events are published and consumed.
+
+### Event Publisher Configuration
+
+If you intend to use the Event Publisher flow, consider the following additional parameter:
+
+- **`eventType`**: The type of the event being published. In the example, it's set to `"DEPLOY_API_IN_GATEWAY"`. Customize this to match your event type.
+
+- **`event`**: A JSON-formatted event payload that you want to publish. Modify the content within the double quotes to match your event's structure and data.
+
+Here's an example configuration:
+
+```properties
+# Broker Configuration
+brokerUrl=tcp://localhost:5672
+username=admin
+password=admin
+topicName=notification
+
+# Event Publisher Configuration
+eventType=DEPLOY_API_IN_GATEWAY
+event={"apiId":0,"uuid":"732e4a17-5767-443d-bf24-319c52948877","name":"asa","version":"v1","provider":"admin","apiType":"HTTP","gatewayLabels":["production and sandbox"],"associatedApis":[],"context":"/asd/v1","eventId":"d1b1dcd6-b387-4fa8-8d3d-9bc4a76dd72b","timeStamp":1693289608077,"type":"DEPLOY_API_IN_GATEWAY","tenantId":0,"tenantDomain":"carbon.super"}
+```
+
+Make sure to modify the values in the `config.properties` file to match your setup and the specific events you're working with.

--- a/JMS-Publisher-Consumer-Client/pom.xml
+++ b/JMS-Publisher-Consumer-Client/pom.xml
@@ -1,0 +1,145 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.wso2.test.jmsPublisherConsumerClient</groupId>
+  <artifactId>JMS-Publisher-Consumer-Client</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <name>JMSTestClient</name>
+  <url>http://maven.apache.org</url>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>11</source>
+          <target>11</target>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.6.0</version> <!-- Update to the latest version -->
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>org.wso2.test.jmsPublisherConsumerClient.EventReceiver</mainClass>
+            </manifest>
+          </archive>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <appendAssemblyId>false</appendAssemblyId>
+        </configuration>
+        <executions>
+          <execution>
+            <id>build-jar-with-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.6.0</version>
+        <configuration>
+          <descriptors>
+            <descriptor>src/main/resources/zip-assembly.xml</descriptor>
+          </descriptors>
+        </configuration>
+        <executions>
+          <execution>
+            <id>create-zip-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <!-- ... Other dependencies ... -->
+
+<properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.wso2.andes.wso2</groupId>
+      <artifactId>andes-client</artifactId>
+      <version>3.3.12</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+
+<!--    <dependency>-->
+<!--      <groupId>org.apache.maven.plugins</groupId>-->
+<!--      <artifactId>maven-assembly-plugin</artifactId>-->
+<!--      <version>3.6.0</version>-->
+<!--    </dependency>-->
+
+    <dependency>
+      <groupId>org.apache.geronimo.specs.wso2</groupId>
+      <artifactId>geronimo-jms_1.1_spec</artifactId>
+      <version>1.1.0.wso2v1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <version>2.5.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>tomcat-jdbc</artifactId>
+      <version>9.0.68</version> <!-- Replace with the desired version -->
+    </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20140107</version>
+    </dependency>
+    <!--    <dependency>-->
+<!--      <groupId>javax</groupId>-->
+<!--      <artifactId>javaee-web-api</artifactId>-->
+<!--      <version>7.0</version>-->
+<!--    </dependency>-->
+  </dependencies>
+
+  <repositories>
+  <repository>
+    <id>wso2-nexus</id>
+    <name>WSO2 internal Repository</name>
+    <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+    <releases>
+      <enabled>true</enabled>
+      <updatePolicy>daily</updatePolicy>
+      <checksumPolicy>ignore</checksumPolicy>
+    </releases>
+  </repository>
+  <repository>
+    <id>wso2.releases</id>
+    <name>WSO2 internal Repository</name>
+    <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+    <releases>
+      <enabled>true</enabled>
+      <updatePolicy>daily</updatePolicy>
+      <checksumPolicy>ignore</checksumPolicy>
+    </releases>
+  </repository>
+  </repositories>
+</project>

--- a/JMS-Publisher-Consumer-Client/src/main/java/org/wso2/test/jmsPublisherConsumerClient/EventPublisher.java
+++ b/JMS-Publisher-Consumer-Client/src/main/java/org/wso2/test/jmsPublisherConsumerClient/EventPublisher.java
@@ -1,0 +1,52 @@
+package org.wso2.test.jmsPublisherConsumerClient;
+
+import org.json.JSONObject;
+
+import javax.jms.*;
+import javax.naming.NamingException;
+import java.util.Base64;
+
+public class EventPublisher extends JMSBase {
+
+    public static void main(String[] args) throws NamingException, JMSException {
+        EventPublisher eventPublisher = new EventPublisher();
+        eventPublisher.start();
+    }
+
+    private static JSONObject buildingTheMessagePayload() {
+        ReadConfigFile config = new ReadConfigFile();
+        String eventType= config.getProperty("eventType");
+        String event= config.getProperty("event");
+        String encodedEvent = Base64.getEncoder().encodeToString(event.getBytes());
+
+
+        JSONObject eventPayloadData = new JSONObject();
+        eventPayloadData.put("eventType", eventType);
+        eventPayloadData.put("timestamp", System.currentTimeMillis());
+        eventPayloadData.put("event", encodedEvent); // your event data
+
+        JSONObject payloadData = new JSONObject();
+        payloadData.put("payloadData", eventPayloadData);
+
+        JSONObject eventObject = new JSONObject();
+        eventObject.put("event", payloadData);
+
+        return eventObject;
+    }
+
+
+    public void start() throws NamingException, JMSException {
+        setupConnection();
+        Topic topic = topicSession.createTopic(topicName);
+        MessageProducer producer = topicSession.createProducer(topic);
+        try {
+
+            TextMessage message = topicSession.createTextMessage(buildingTheMessagePayload().toString());
+            producer.send(message);
+        } catch (JMSException e) {
+            System.out.println("! Event was not published to the broker !");
+            e.printStackTrace();
+        }
+        System.out.println("! Event was successfully published to the broker !");
+    }
+}

--- a/JMS-Publisher-Consumer-Client/src/main/java/org/wso2/test/jmsPublisherConsumerClient/EventReceiver.java
+++ b/JMS-Publisher-Consumer-Client/src/main/java/org/wso2/test/jmsPublisherConsumerClient/EventReceiver.java
@@ -1,0 +1,59 @@
+package org.wso2.test.jmsPublisherConsumerClient;
+
+import javax.jms.*;
+import javax.naming.NamingException;
+
+import wiremock.com.fasterxml.jackson.core.JsonProcessingException;
+import wiremock.com.fasterxml.jackson.databind.JsonNode;
+import wiremock.com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.Base64;
+
+public class EventReceiver extends JMSBase implements MessageListener {
+
+    public static void main(String[] args) throws NamingException, JMSException {
+        EventReceiver eventReceiver = new EventReceiver();
+        eventReceiver.start();
+    }
+
+    public void start() throws NamingException, JMSException {
+        setupConnection();
+        Topic topic = topicSession.createTopic(topicName);
+        MessageConsumer consumer = topicSession.createConsumer(topic);
+        consumer.setMessageListener(this);
+        System.out.println("\n\nEvent receiver started and Listening to " + brokerUrl);
+    }
+
+    public static String decodeBase64(String base64EncodedString) {
+        byte[] decodedBytes = Base64.getDecoder().decode(base64EncodedString);
+        return new String(decodedBytes);
+    }
+
+    @Override
+    public void onMessage(Message message) {
+        try {
+            Topic jmsDestination = (Topic) message.getJMSDestination();
+            if (message instanceof TextMessage) {
+                String textMessage = ((TextMessage) message).getText();
+                JsonNode payloadData = new ObjectMapper().readTree(textMessage).path("event").path("payloadData");
+                    System.out.println("-------- EVENT RECEIVED -------------");
+                    System.out.println("EVENT RECEIVED :" + payloadData);
+                String event = payloadData.get("event").asText();
+                if (event != null && !event.isEmpty()){
+                    System.out.println("DECRYPTED PAYLOAD :" +decodeBase64(event));
+                }
+
+                System.out.println("----------------------------");
+
+            }
+        } catch (JMSException e) {
+            System.out.print("Error While Reading The JMS Message " + e.getMessage());
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/JMS-Publisher-Consumer-Client/src/main/java/org/wso2/test/jmsPublisherConsumerClient/JMSBase.java
+++ b/JMS-Publisher-Consumer-Client/src/main/java/org/wso2/test/jmsPublisherConsumerClient/JMSBase.java
@@ -1,0 +1,43 @@
+package org.wso2.test.jmsPublisherConsumerClient;
+
+import javax.jms.*;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.util.Properties;
+public class JMSBase {
+    protected TopicConnection topicConnection;
+    protected TopicSession topicSession;
+
+    protected String brokerUrl = "tcp://0.0.0.0:5672";
+    protected String username = "admin";
+    protected String password = "admin";
+    protected String topicName = "notification";
+
+    private void readProperties(){
+        ReadConfigFile config = new ReadConfigFile();
+        brokerUrl = config.getProperty("brokerUrl");
+        username = config.getProperty("username");
+        password = config.getProperty("password");
+        topicName = config.getProperty("topicName");
+    }
+    protected void setupConnection() throws NamingException, JMSException {
+        readProperties();
+        Properties properties = new Properties();
+        properties.put("java.naming.factory.initial", "org.wso2.andes.jndi.PropertiesFileInitialContextFactory");
+        properties.put("transport.jms.DestinationType", "topic");
+        properties.put("connectionfactory.TopicConnectionFactory",
+                "amqp://" + username + ":" + password + "@clientid/carbon?brokerlist='" + brokerUrl + "'");
+        properties.put("transport.jms.ConnectionFactoryJNDIName", "TopicConnectionFactory");
+
+        InitialContext ctx = new InitialContext(properties);
+        TopicConnectionFactory connFactory = (TopicConnectionFactory) ctx.lookup("TopicConnectionFactory");
+
+        topicConnection = connFactory.createTopicConnection();
+        topicConnection.start();
+        topicSession = topicConnection.createTopicSession(false, TopicSession.AUTO_ACKNOWLEDGE);
+    }
+
+    protected void closeConnection() throws JMSException {
+        topicConnection.close();
+    }
+}

--- a/JMS-Publisher-Consumer-Client/src/main/java/org/wso2/test/jmsPublisherConsumerClient/ReadConfigFile.java
+++ b/JMS-Publisher-Consumer-Client/src/main/java/org/wso2/test/jmsPublisherConsumerClient/ReadConfigFile.java
@@ -1,0 +1,55 @@
+package org.wso2.test.jmsPublisherConsumerClient;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * Read configurations from config.xml file.
+ */
+public class ReadConfigFile {
+    private Properties properties = new Properties();
+
+    /**
+     * Read config.file.
+     */
+    public ReadConfigFile() {
+
+        // Load properties from external file if it exists
+        try {
+            InputStream externalInput = new FileInputStream("config.properties");
+            properties.load(externalInput);
+            externalInput.close();
+        } catch (IOException e) {
+            System.out.println("External Config file not found.");
+            e.printStackTrace();
+            // External file doesn't exist or couldn't be read
+        }
+
+        // Load default properties from JAR if not overridden externally
+        if (properties.isEmpty()) {
+            System.out.println("Reading  internal config file");
+            try {
+                InputStream internalInput = ReadConfigFile.class.getClassLoader().getResourceAsStream("config.properties");
+                if (internalInput != null) {
+                    properties.load(internalInput);
+                    internalInput.close();
+                } else {
+                    System.err.println("config.properties file not found.");
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    /**
+     * get the value related to a property.
+     * @param key key of a property.
+     * @return value of property.
+     */
+    public String getProperty(String key) {
+        return properties.getProperty(key);
+    }
+}

--- a/JMS-Publisher-Consumer-Client/src/main/resources/config.properties
+++ b/JMS-Publisher-Consumer-Client/src/main/resources/config.properties
@@ -1,0 +1,8 @@
+brokerUrl=tcp://localhost:5672
+username=admin
+password=admin
+topicName=notification
+
+#Following configuration are only required for Event Publisher flow
+eventType="DEPLOY_API_IN_GATEWAY"
+event="{"apiId":0,"uuid":"732e4a17-5767-443d-bf24-319c52948877","name":"asa","version":"v1","provider":"admin","apiType":"HTTP","gatewayLabels":["production and sandbox"],"associatedApis":[],"context":"/asd/v1","eventId":"d1b1dcd6-b387-4fa8-8d3d-9bc4a76dd72b","timeStamp":1693289608077,"type":"DEPLOY_API_IN_GATEWAY","tenantId":0,"tenantDomain":"carbon.super"}"

--- a/JMS-Publisher-Consumer-Client/src/main/resources/zip-assembly.xml
+++ b/JMS-Publisher-Consumer-Client/src/main/resources/zip-assembly.xml
@@ -1,0 +1,16 @@
+<assembly>
+    <id>my-zip-assembly</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <files>
+        <file>
+            <source>${project.build.directory}/${project.build.finalName}.jar</source>
+            <outputDirectory>/</outputDirectory>
+        </file>
+        <file>
+            <source>${project.basedir}/src/main/resources/config.properties</source>
+            <outputDirectory>/</outputDirectory>
+        </file>
+    </files>
+</assembly>

--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ This repo contains the tools, utilities and some usefull commands help to troubl
 - [HAR Capture](HAR-capture/README.md)
 - [APIM 3.2.0 deployment](scripts-and-commands/distributed-deployment/apim-3.2.0/README.md)
 - [APIM 4.0.0 deployment](scripts-and-commands/distributed-deployment/apim-4.0.0/README.md)
+- [JMS Publisher/Consumer Client](JMS-Publisher-Consumer-Client/)


### PR DESCRIPTION
## Description

This pull request introduces a JMS Consumer/Publisher Client tool to address situations where JMS events might not be consumed correctly by the gateway, as indicated by the gateway listener debug logs. Even though the event publisher log adaptor is configured for the relevant stream, showing that the message was received in the event stream, it doesn't necessarily confirm the proper publication of the event to the broker through the JMSeventPublisher. This tool provides a solution by allowing manual verification of event publication and consumption, aiding in identifying any issues between the JMS publisher flow and the consumption flow.

## Changes Made

- Added a JMS Consumer/Publisher Client tool to the project.
- Provided instructions for building and using the tool in the README.
- updated the root readMe file by adding the link to JMS consumer publisher client 
