### PR TITLE
Add thread dump collection script for Mac

### DIFF
--- a/scripts-and-commands/thread-dump/README.md
+++ b/scripts-and-commands/thread-dump/README.md
@@ -15,7 +15,7 @@ Available time units
 - m for minutes.
 - h for hours.
 - d for days.
-- 
+
 ## Thread dump script for windows
 
 You can use this windows script thread-analyze-windows.bat to get 4 thread dumps with one minute (60 seconds ) interval.
@@ -27,3 +27,19 @@ Execute the script using below command
 thread-analyze-windows.bat <PID>
 ```
 
+## Thread dump script for Mac
+
+This script is designed for a Mac system.
+
+### How to get ?
+
+Execute the script using below command
+```
+sh thread-analyze-mac.sh <PID> <number-of-dumps> <interval>[s|m|h|d]
+```
+
+### Note
+In case of any error, you will need to execute the below command. This part of the command allows you to run the script as the specified user.
+```
+sudo -u <user> sh thread-analyze-mac.sh <PID> <number-of-dumps> <interval>[s|m|h|d]
+```

--- a/scripts-and-commands/thread-dump/thread-analyze-mac.sh
+++ b/scripts-and-commands/thread-dump/thread-analyze-mac.sh
@@ -2,7 +2,7 @@
 
 # Check number of arguments
 if [ "$#" -ne 3 ]; then
-    echo "usage: sh thread-analyze.sh <pid> <number-of-dumps> <interval>[s|m|h|d]"
+    echo "usage: sh thread-analyze-mac.sh <PID> <number-of-dumps> <interval>[s|m|h|d]"
     exit 1
 fi
 

--- a/scripts-and-commands/thread-dump/thread-analyze-mac.sh
+++ b/scripts-and-commands/thread-dump/thread-analyze-mac.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Check number of arguments
+if [ "$#" -ne 3 ]; then
+    echo "usage: sh thread-analyze.sh <pid> <number-of-dumps> <interval>[s|m|h|d]"
+    exit 1
+fi
+
+count=$2
+interval_input=$3
+
+# Function to convert interval to seconds
+convert_to_seconds() {
+    local value=${1%[smhd]}
+    local unit=${1: -1}
+
+    case "$unit" in
+        s) echo $value ;;
+        m) echo $((value * 60)) ;;
+        h) echo $((value * 3600)) ;;
+        d) echo $((value * 86400)) ;;
+        *) echo $value ;;  # Default to seconds if no unit is provided
+    esac
+}
+
+for i in $(seq 1 $count); do
+    jstack -l $1 > "thread_dump_$(date "+%F-%T").txt" &
+    ps -p $1 -M > "thread_usage_$(date "+%F-%T").txt" &
+    if [ $i -ne $count ]; then
+        interval_seconds=$(convert_to_seconds $interval_input)
+        echo "sleeping for $interval_input [$i]"
+        sleep $interval_seconds
+    fi
+done


### PR DESCRIPTION
## Thread dump script for Mac

This script is designed for a Mac system.

### How to get ?

Execute the script using below command
```
sh thread-analyze-mac.sh <PID> <number-of-dumps> <interval>[s|m|h|d]
```

### Note
In case of any error, you will need to execute the below command. This part of the command allows you to run the script as the specified user.
```
sudo -u <user> sh thread-analyze-mac.sh <PID> <number-of-dumps> <interval>[s|m|h|d]
```